### PR TITLE
KON-434: Use PHP 7.4 in GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
             -   name: Setup PHP, with composer and extensions
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.3
+                    php-version: 7.4
                     extensions: ctype, dom, iconv, json, zip, gd, soap
                     coverage: none
                     tools: composer:v1
@@ -25,7 +25,7 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: ctype, dom, iconv, json, zip, gd, soap
                   coverage: none
                   tools: composer:v1
@@ -49,7 +49,7 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: ctype, dom, iconv, json, zip, gd, soap
                   coverage: none
                   tools: composer:v1
@@ -68,7 +68,7 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: ctype, dom, iconv, json, zip, gd, soap
                   coverage: none
                   tools: composer:v1
@@ -87,7 +87,7 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: ctype, dom, iconv, json, zip, gd, soap
                   coverage: none
                   tools: composer:v1
@@ -112,7 +112,7 @@ jobs:
           - name: Setup PHP, with composer and extensions
             uses: shivammathur/setup-php@v2
             with:
-                php-version: 7.3
+                php-version: 7.4
                 extensions: ctype, dom, iconv, json, zip, gd, sqlite3, pdo, soap
                 coverage: none
                 tools: composer:v1


### PR DESCRIPTION
https://jira.itkdev.dk/browse/KON-434

Use PHP 7.4 in GitHub Actions