### PR TITLE
Release 2.0.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,23 @@
 on: pull_request
 name: Review
 jobs:
+    changelog:
+        runs-on: ubuntu-latest
+        name: Changelog should be updated
+        strategy:
+            fail-fast: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 2
+
+            - name: Git fetch
+              run: git fetch
+
+            - name: Check that changelog has been updated.
+              run: git diff --exit-code origin/${{ github.base_ref }} -- CHANGELOG.md && exit 1 || exit 0
+
     test-composer-files:
         name: Validate composer
         runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,114 +1,203 @@
+<!-- markdownlint-disable MD024 -->
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2023-02-21
+
 ### Changed
+
 - Added core bundle to `core/` directory
 
 ## [1.12.2] - 2021-12-14
+
 ### Changed
+
 - Required Core Bundle version 1.12.2.
 
 ## [1.12.0] - 2021-09-14
+
 ### Changed
+
 - Required Core Bundle version 1.12.0.
 
 ## [1.11.5] - 2021-06-11
+
 ### Changed
+
 - Required Core Bundle version 1.11.5.
 
 ## [1.11.4] - 2021-06-04
+
 ### Changed
+
 - Required Core Bundle version 1.11.3.
 
 ## [1.11.3] - 2021-04-07
+
 ### Changed
+
 - Required Core Bundle version 1.11.3.
 
 ## [1.11.2] - 2021-03-23
+
 ### Changed
+
 - Required Core Bundle version 1.11.2.
 
 ## [1.11.1] - 2021-03-22
+
 ### Changed
+
 - Required Core Bundle version 1.11.1.
 
 ## [1.11.0] - 2021-02-13
+
 ### Changed
+
 - Required Core Bundle version 1.11.0.
 
 ### Fixed
-- [KON-436](https://jira.itkdev.dk/browse/KON-436): Removing failing slack notification from Jenkinsfile.
+
+- [KON-436](https://jira.itkdev.dk/browse/KON-436): Removing failing slack
+  notification from Jenkinsfile.
 
 ## [1.10.0] - 2021-02-15
+
 ### Changed
+
 - Required Core Bundle version 1.10.0.
 
 ### Added
-- [SUPP0RT-62](https://jira.itkdev.dk/browse/SUPP0RT-62): Added documentation on fixtures and docker image.
-- [SUPP0RT-62](https://jira.itkdev.dk/browse/SUPP0RT-62): Added missing environment variables
+
+- [SUPP0RT-62](https://jira.itkdev.dk/browse/SUPP0RT-62): Added documentation on
+  fixtures and docker image.
+- [SUPP0RT-62](https://jira.itkdev.dk/browse/SUPP0RT-62): Added missing
+  environment variables
 
 ## [1.9.0] - 2021-01-04
+
 ### Changed
+
 - Required version 1.9.0 of core bundle.
 
 ## [1.8.0] - 2020-11-19
+
 ### Changed
+
 - Required version 1.8.0 of core bundle.
 
 ## [1.7.5] - 2020-11-16
+
 ### Changed
+
 - Required version 1.7.5 of core bundle.
 
 ## [1.7.4] - 2020-10-29
+
 ### Changed
+
 - Required version 1.7.4 of core bundle.
 
 ## [1.7.3] - 2020-10-21
+
 ### Changed
+
 - Disabled Serviceplatformen. Enabled internal CPR service.
 
 ## [1.7.2] - 2020-10-01
+
 ### Changed
+
 - Required version 1.7.2 of core bundle.
 
 ## [1.7.1] - 2020-09-17
+
 ### Changed
-- [KON-395](https://jira.itkdev.dk/browse/KON-395): Required version 1.7.1 of core bundle
+
+- [KON-395](https://jira.itkdev.dk/browse/KON-395): Required version 1.7.1 of
+  core bundle
 - [KON-396](https://jira.itkdev.dk/browse/KON-396): Feedback changes
 
 ## [1.7.0] - 2020-08-03
+
 ### Added
-- [KON-288](https://jira.itkdev.dk/browse/KON-288): Added links between processes
-- [KON-356](https://jira.itkdev.dk/browse/KON-356): Added weekly choice when entering future savings revenue entries
+
+- [KON-288](https://jira.itkdev.dk/browse/KON-288): Added links between
+  processes
+- [KON-356](https://jira.itkdev.dk/browse/KON-356): Added weekly choice when
+  entering future savings revenue entries
 
 ### Changed
+
 - Required version 1.6.9 of bundle
 
 ## [1.6.9] - 2020-06-30
+
 ### Changed
+
 - Required version 1.6.9 of bundle (hotfix)
 
 ## [1.6.8] - 2020-06-26
+
 ### Added
-- [KON-330](https://jira.itkdev.dk/browse/KON-330): Mark statuses for use when completing processes
-- [KON-364](https://jira.itkdev.dk/browse/KON-364): Preventing double submissions when creating new journal entry
+
+- [KON-330](https://jira.itkdev.dk/browse/KON-330): Mark statuses for use when
+  completing processes
+- [KON-364](https://jira.itkdev.dk/browse/KON-364): Preventing double
+  submissions when creating new journal entry
 
 ## [1.6.7] - 2020-05-20
+
 ### Changed
+
 - Required version 1.6.7 of bundle.
 
 ## [1.6.5] - 2020-05-20
+
 ### Changed
+
 - Required version 1.6.6 of bundle.
 
 ## [1.6.4] - 2020-05-19
+
 ### Added
+
 - Added CHANGELOG file
-- [KON-289](https://jira.itkdev.dk/browse/KON-289): Show name of user when hovering AZ
+- [KON-289](https://jira.itkdev.dk/browse/KON-289): Show name of user when
+  hovering AZ
 
 ### Changed
+
 - [KON-361](https://github.com/aakb/kontrolgruppen/pull/81): Changed datepicker
+
+[Unreleased]: https://github.com/itk-dev/kontrolgruppen/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.12.2...2.0.0
+[1.12.2]: https://github.com/itk-dev/kontrolgruppen/compare/1.12.0...1.12.2
+[1.12.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.11.5...1.12.0
+[1.11.5]: https://github.com/itk-dev/kontrolgruppen/compare/.1.11.4..1.11.5
+[1.11.4]: https://github.com/itk-dev/kontrolgruppen/compare/1.11.3...1.11.4
+[1.11.3]: https://github.com/itk-dev/kontrolgruppen/compare/1.11.2...1.11.3
+[1.11.2]: https://github.com/itk-dev/kontrolgruppen/compare/1.11.2...1.11.2
+[1.11.1]: https://github.com/itk-dev/kontrolgruppen/compare/1.11.0...1.11.1
+[1.11.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.10.1...1.11.0
+[1.10.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.9.0...1.10.1
+[1.9.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.8.0...1.9.0
+[1.8.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.5...1.8.0
+[1.7.5]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.4...1.7.5
+[1.7.4]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.3...1.7.4
+[1.7.3]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.2...1.7.3
+[1.7.2]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.1...1.7.2
+[1.7.1]: https://github.com/itk-dev/kontrolgruppen/compare/1.7.0...1.7.1
+[1.7.0]: https://github.com/itk-dev/kontrolgruppen/compare/1.6.9...1.7.0
+[1.6.9]: https://github.com/itk-dev/kontrolgruppen/compare/1.6.8...1.6.9
+[1.6.8]: https://github.com/itk-dev/kontrolgruppen/compare/1.6.7...1.6.8
+[1.6.7]: https://github.com/itk-dev/kontrolgruppen/compare/1.6.5...1.6.7
+[1.6.5]: https://github.com/itk-dev/kontrolgruppen/compare/1.6.4...1.6.5
+[1.6.4]: https://github.com/itk-dev/kontrolgruppen/releases/tag/1.6.4

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,7 @@ docker compose exec phpfpm bin/console kontrolgruppen:user:login admin@example.c
 
 ## Starting the show
 
-The `docker-compose` setup uses a custom image hosted on GitHub, and you have to
+The `docker compose` setup uses a custom image hosted on GitHub, and you have to
 sign in to download this image.
 
 Go to <https://github.com/settings/tokens/new> and create a new personal access
@@ -39,14 +39,14 @@ to sign in (cf.
 <https://docs.github.com/en/packages/guides/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token>).
 
 ```sh
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 Open the site in your default browser:
 
 ```sh
-open http://$(docker-compose port nginx 80)
+open http://$(docker compose port nginx 80)
 ```
 
 ## Setup for development
@@ -57,10 +57,10 @@ composer install
 
 # Migrate database.
 # If using docker these bin/console commands should be run from inside the phpfpm container.
-docker-compose exec phpfpm /app/bin/console doctrine:migrations:migrate
+docker compose exec phpfpm /app/bin/console doctrine:migrations:migrate
 
 # Create super admin user.
-docker-compose exec phpfpm /app/bin/console fos:user:create --super-admin
+docker compose exec phpfpm /app/bin/console fos:user:create --super-admin
 ```
 
 ## Fixtures
@@ -68,13 +68,13 @@ docker-compose exec phpfpm /app/bin/console fos:user:create --super-admin
 You can load fixtures by running the command
 
 ```sh
-docker-compose exec phpfpm bin/console doctrine:fixtures:load
+docker compose exec phpfpm bin/console doctrine:fixtures:load
 ```
 
 and then use
 
 ```sh
-docker-compose exec phpfpm bin/console kontrolgruppen:user:login admin@example.com
+docker compose exec phpfpm bin/console kontrolgruppen:user:login admin@example.com
 ```
 
 to get a one-time sign in url.
@@ -83,13 +83,13 @@ to get a one-time sign in url.
 
 ```sh
 # Make sure that the database is created
-docker-compose exec borgerdata node createdb.js
+docker compose exec borgerdata node createdb.js
 
 # Migrate database
-docker-compose exec borgerdata yarn knex migrate:latest
+docker compose exec borgerdata yarn knex migrate:latest
 
 # Seed the database
-docker-compose exec borgerdata yarn knex seed:run
+docker compose exec borgerdata yarn knex seed:run
 ```
 
 ## Use maker bundle
@@ -107,7 +107,7 @@ This will place the files in the correct location.
 Watch for changes in js and css files and build development version:
 
 ```sh
-docker-compose run node yarn watch
+docker compose run --rm node yarn watch
 ```
 
 ## Coding standards
@@ -139,13 +139,13 @@ composer check-coding-standards/twigcs
 Check JavaScript files using [eslint](https://eslint.org/):
 
 ```sh
-docker-compose run node yarn check-coding-standards-js
+docker compose run --rm node yarn check-coding-standards-js
 ```
 
 Apply coding standards:
 
 ```sh
-docker-compose run node yarn apply-coding-standards-js
+docker compose run --rm node yarn apply-coding-standards-js
 ```
 
 ### SCSS
@@ -153,13 +153,13 @@ docker-compose run node yarn apply-coding-standards-js
 Check SCSS files using [stylelint](https://stylelint.io/):
 
 ```sh
-docker-compose run node yarn check-coding-standards-scss
+docker compose run --rm node yarn check-coding-standards-scss
 ```
 
 Apply coding standards:
 
 ```sh
-docker-compose run node yarn apply-coding-standards-scss
+docker compose run --rm node yarn apply-coding-standards-scss
 ```
 
 ## Code analysis

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
         "check-coding-standards-scss": "yarn run check-coding-standards-stylelint",
         "check-coding-standards-eslint": "eslint --config .eslintrc.js 'core/Resources/assets/**/*.js'",
         "check-coding-standards-js": "yarn run check-coding-standards-eslint",
-        "check-coding-standards-markdownlint": "markdownlint README.md 'docs/**/*.md'",
+        "check-coding-standards-markdownlint": "markdownlint *.md 'docs/**/*.md'",
         "check-coding-standards": "yarn run check-coding-standards-scss; yarn run check-coding-standards-js; yarn run check-coding-standards-markdownlint",
         "apply-coding-standards-stylelint": "stylelint --config=.stylelintrc.js 'core/Resources/assets/**/*.scss' --fix",
         "apply-coding-standards-scss": "yarn run apply-coding-standards-stylelint",
         "apply-coding-standards-eslint": "eslint --config .eslintrc.js 'core/Resources/assets/**/*.js' --fix",
         "apply-coding-standards-js": "yarn run apply-coding-standards-eslint",
-        "apply-coding-standards-markdownlint": "markdownlint --fix README.md 'docs/**/*.md'",
+        "apply-coding-standards-markdownlint": "markdownlint --fix *.md 'docs/**/*.md'",
         "apply-coding-standards": "yarn run apply-coding-standards-scss; yarn run apply-coding-standards-js; yarn run apply-coding-standards-markdownlint"
     },
     "engines": {


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TJEK1-434

Release 2.0.0

Moves everything into a single repository making [itk-dev/kontrolgruppen-core-bundle](https://github.com/itk-dev/kontrolgruppen-core-bundle) obsolete. 🎉 

