### PR TITLE
SUPP0RT-884: Upgraded LexikFormFilterBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded to LexikFormFilterBundle v7
+
 ## [2.0.0] - 2023-02-21
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "friendsofsymfony/ckeditor-bundle": "^2.0",
         "itk-dev/serviceplatformen": "^1.1",
         "knplabs/knp-paginator-bundle": "^3.0",
-        "lexik/form-filter-bundle": "^5.0",
+        "lexik/form-filter-bundle": "^7.0",
         "mpdf/mpdf": "^8.0.2",
         "nyholm/psr7": "^1.4",
         "ocramius/doctrine-batch-utils": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b166b11e622f4cd4498e00b3b3aacf34",
+    "content-hash": "14dacf7deb6d9f3eebd7d8b4fd2ef901",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -2328,37 +2328,34 @@
         },
         {
             "name": "lexik/form-filter-bundle",
-            "version": "v5.0.10",
+            "version": "v7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lexik/LexikFormFilterBundle.git",
-                "reference": "92df0638173979dc906bda7a33a10b98429d2057"
+                "reference": "7588970d84c1604b98743588ba9020f6bddf6303"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lexik/LexikFormFilterBundle/zipball/92df0638173979dc906bda7a33a10b98429d2057",
-                "reference": "92df0638173979dc906bda7a33a10b98429d2057",
+                "url": "https://api.github.com/repos/lexik/LexikFormFilterBundle/zipball/7588970d84c1604b98743588ba9020f6bddf6303",
+                "reference": "7588970d84c1604b98743588ba9020f6bddf6303",
                 "shasum": ""
             },
             "require": {
-                "doctrine/orm": "^2.4.8",
-                "php": ">=5.5.9",
-                "symfony/form": "~2.8|~3.0|^4.0",
-                "symfony/framework-bundle": "~2.8|~3.0|^4.0"
+                "doctrine/orm": "^2.10",
+                "php": ">=7.1",
+                "symfony/form": "^4.4|^5.1|^6.0",
+                "symfony/framework-bundle": "^4.4|^5.1|^6.0"
             },
             "require-dev": {
-                "doctrine/mongodb-odm-bundle": "^3.0",
-                "phpunit/phpunit": "~5.0|^7.5"
+                "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+                "doctrine/mongodb-odm-bundle": "^4.1",
+                "symfony/phpunit-bridge": "^4.4|^5.1|^6.0",
+                "symfony/var-dumper": "^4.4|^5.1|^6.0"
             },
             "suggest": {
                 "alcaeus/mongo-php-adapter": "Install this package if using the PHP 7 MongoDB Driver"
             },
             "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Lexik\\Bundle\\FormFilterBundle\\": ""
@@ -2370,12 +2367,12 @@
             ],
             "authors": [
                 {
-                    "name": "Dev Lexik",
-                    "email": "dev@lexik.fr"
-                },
-                {
                     "name": "Cedric Girard",
                     "email": "c.girard@lexik.fr"
+                },
+                {
+                    "name": "Dev Lexik",
+                    "email": "dev@lexik.fr"
                 }
             ],
             "description": "This bundle aim to provide classes to build some form filters and then build a doctrine query from this form filter.",
@@ -2389,9 +2386,9 @@
             ],
             "support": {
                 "issues": "https://github.com/lexik/LexikFormFilterBundle/issues",
-                "source": "https://github.com/lexik/LexikFormFilterBundle/tree/master"
+                "source": "https://github.com/lexik/LexikFormFilterBundle/tree/v7.0.3"
             },
-            "time": "2019-04-17T17:58:44+00:00"
+            "time": "2022-07-28T11:49:50+00:00"
         },
         {
             "name": "maennchen/zipstream-php",


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-884

Upgrades to LexikFormFilterBundle v7 to fix 

```
Undefined constant Doctrine\DBAL\Types\Type::STRING
```

error (cf. <https://github.com/lexik/LexikFormFilterBundle/issues/353>).

